### PR TITLE
Add support for (non-)legit workday of China

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For users in China, you can also download the **xiaomi.eu rom** and run `cleaner
 * Fix FC of cleaner app.
 * Show payment monitor options in setting page of Security app.
 * Use Chinese weather sources in Weather app.
+* Allow alarm of legal workday repeat mode.
 
 ## (Optional) Encryption for xiaomi.eu ROMs
 


### PR DESCRIPTION
This pull request aims to support repeat option of (non-)legit workdays in Clock app, by bypassing international build detect.
Verified on MIUI EU 8.9.20 / MIX 2S.

I don't know much about bash shell so it may look ugly and need some polish. Thanks.